### PR TITLE
Fix for Mutex regression in 1.9

### DIFF
--- a/lib/net/ssh/gateway.rb
+++ b/lib/net/ssh/gateway.rb
@@ -192,6 +192,7 @@ class Net::SSH::Gateway
           @session_mutex.synchronize do
             @session.process(0.1)
           end
+          Thread.pass
         end
       end
     end


### PR DESCRIPTION
Hi Jamis, 

Attached is a simple one-liner to resolve a regression that popped up somewhere between 1.8.7 and 1.9.1 (one assumes it cropped up in 1.9, but I haven't isolated that). The regression was causing gateway-ed connections to take a long and variable time to start up and tear down (often causing delays of several minutes in cap recipes that use Gateway connections). This one liner fixes the bug in 1.9, and doesn't affect the existing (correct) behaviour in 1.8. 

In short, it appears that 1.9's Mutex has changed to honour requests on the current thread before those on other threads, even if the other thread's request occurred earlier in temporal order. So in the case of net-ssh-gateway, the eventloop thread's tight loop around the session mutex causes any other requests for that mutex (like, for example, the mutex request in close()) to be starved until the eventloop thread gets descheduled. The fix is an easy one, and just explicitly deschedules the eventloop thread at the end of every turn around the event loop. 

As it stands this isn't technically an MRI or stdlib bug, as far as I can tell. What the Mutex _should_ be doing isn't documented; there's nothing inherent in the strict definition of a (lowercase-m) mutex requiring that waiters be served in arrival order, though that is the typical case and the usual expected behaviour of a mutex. I've looked high and low and can't find a definitive answer about the expected behaviour of Ruby's (big-M) Mutex in this regard (sadly, I can't dive into the MRI codebase to spelunk, I'm on deadline. Maybe later.). 
