### PR TITLE
We've found in ruby 1.9 we're getting sporadicly stalled SSH connections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source :rubygems
+
+gemspec
+
+gem "echoe"
+gem "mocha"

--- a/lib/net/ssh/gateway.rb
+++ b/lib/net/ssh/gateway.rb
@@ -190,7 +190,7 @@ class Net::SSH::Gateway
       @thread = Thread.new do
         while @active
           @session_mutex.synchronize do
-            @session.process(0.1)
+            @session.process(0.001)
           end
           Thread.pass
         end

--- a/lib/net/ssh/gateway.rb
+++ b/lib/net/ssh/gateway.rb
@@ -192,6 +192,7 @@ class Net::SSH::Gateway
           @session_mutex.synchronize do
             @session.process(0.1)
           end
+          Thread.pass
         end
       end
     end

--- a/net-ssh-gateway.gemspec
+++ b/net-ssh-gateway.gemspec
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = %q{net-ssh-gateway}
+  s.version = "1.0.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Jamis Buck"]
+  s.date = %q{2011-03-03}
+  s.description = %q{A simple library to assist in establishing tunneled Net::SSH connections}
+  s.email = %q{jamis@jamisbuck.org}
+  s.extra_rdoc_files = ["CHANGELOG.rdoc", "lib/net/ssh/gateway.rb", "README.rdoc"]
+  s.files = ["CHANGELOG.rdoc", "lib/net/ssh/gateway.rb", "Manifest", "Rakefile", "README.rdoc", "setup.rb", "test/gateway_test.rb", "net-ssh-gateway.gemspec"]
+  s.homepage = %q{http://net-ssh.rubyforge.org/gateway}
+  s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Net-ssh-gateway", "--main", "README.rdoc"]
+  s.require_paths = ["lib"]
+  s.rubyforge_project = %q{net-ssh-gateway}
+  s.rubygems_version = %q{1.3.7}
+  s.summary = %q{A simple library to assist in establishing tunneled Net::SSH connections}
+  s.test_files = ["test/gateway_test.rb"]
+
+  if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<net-ssh>, [">= 1.99.1"])
+    else
+      s.add_dependency(%q<net-ssh>, [">= 1.99.1"])
+    end
+  else
+    s.add_dependency(%q<net-ssh>, [">= 1.99.1"])
+  end
+end


### PR DESCRIPTION
We've found in ruby 1.9 we're getting sporadicly stalled SSH connections. It looks like Net::SSH is waiting for openssh and openssh is waiting for Net::SSH. When we decreased the wait time for process we were able to succesfully use capistrano's gateway feature again.

This may actually be a bug in Net::SSH Session#process (we are using 2.1.3) but this resolves the issue for us.
